### PR TITLE
Use branch name in version

### DIFF
--- a/modules/pipeline_steps/image_version_step.py
+++ b/modules/pipeline_steps/image_version_step.py
@@ -32,7 +32,7 @@ class ImageVersionStep(AbstractPipelineStep):
                                    .format(image_version))
         branch_name = environment.get_git_branch()
         if not branch_name in ('master', 'main'):
-            return "{}+{}.{}".format(image_version, slugify(branch_name), patch_version)
+            return "{}-{}.{}".format(slugify(branch_name), image_version, patch_version)
         else:
             return "{}.{}".format(image_version, patch_version)
 

--- a/test/unit_tests/test_image_version_step.py
+++ b/test/unit_tests/test_image_version_step.py
@@ -9,11 +9,13 @@ from modules.util import environment
 class ImageVersionStepTests(unittest.TestCase):
 
     def test_format_image_version_with_build_number_as_patch(self):
+        os.environ[environment.GIT_BRANCH] = 'master'
         ivs = ImageVersionStep()
         result = ivs.get_sem_ver('1.2', 123)
         self.assertEqual(result, '1.2.123')
 
     def test_format_image_version_to_long(self):
+        os.environ[environment.GIT_BRANCH] = 'master'
         ivs = ImageVersionStep()
         ImageVersionStep.handle_step_error = mock.MagicMock()
         ivs.get_sem_ver('1.2.321', 1)


### PR DESCRIPTION
When building something that is not the master (or main) brach, it is important that the resulting artifacts should not be confused with those from the master branch.

Given IMAGE_VERSION=47.11 and build number 17, a build from the master branch should produce artifacts for version 47.11.17, but a build from e.g. feature/new-stuff should produce artifacts for 47.11+feature.new.stuff.17.

The actual code change here is an untested suggestion for how to do this.