### PR TITLE
Add step to inject workspace packages in a monorepos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Evolene CI
 
-on:  
+on: 
   push:
     paths-ignore:
           - '*.md'
@@ -18,6 +18,8 @@ jobs:
           SLACK_CHANNELS: "#team-pipeline-build"
           BUILD_INFORMATION_OUTPUT_FILE: "/version.conf"
           PUSH_PUBLIC: True
+          BRANCHES_SAVE_STARTING_WITH: 'refs/heads/feature-inject-local-workspace-packages'
+          BRANCHES_TAG_AS_MAIN: 'True'
           EVOLENE_TEST_SECRETS: "${{secrets.EVOLENE_TEST_SECRETS}}"
         run: |
           ${{ secrets.EVOLENE_RUN_COMMAND }}

--- a/README-DEVLOPER.md
+++ b/README-DEVLOPER.md
@@ -9,8 +9,8 @@ To run the tests you need pipenv. Install it using the macOS package manager htt
 brew install pipenv
 ```
 
-2. Run tests
+2. Run tests (INSTALL=True is only required on first run)
 
 ```sh
-./run_tests.sh
+INSTALL=True ./run_tests_in_docker.sh
 ```

--- a/README-DEVLOPER.md
+++ b/README-DEVLOPER.md
@@ -1,0 +1,16 @@
+# Developing Evolene
+
+## macOS
+To run the tests you need pipenv. Install it using the macOS package manager https://brew.sh/
+
+1. Install pipenv
+
+```sh
+brew install pipenv
+```
+
+2. Run tests
+
+```sh
+./run_tests.sh
+```

--- a/modules/pipeline_steps/inject_npm_workspace_packages.py
+++ b/modules/pipeline_steps/inject_npm_workspace_packages.py
@@ -1,0 +1,57 @@
+__author__ = 'tinglev'
+
+import sys
+import os
+import json
+import shutil
+from modules.pipeline_steps.abstract_pipeline_step import AbstractPipelineStep
+from modules.util import environment
+from modules.util import pipeline_data
+from modules.util.exceptions import PipelineException
+from modules.util import file_util, text_cleaner
+from modules.util import ci_status
+
+# TODO: Consider more fine grained exception handling using PipelineException
+
+class InjectNpmWorkspacePackages(AbstractPipelineStep):
+
+    name = "Build Docker image"
+    def get_required_env_variables(self):
+        return [environment.PROJECT_ROOT]
+
+    def get_required_data_keys(self):
+        return [pipeline_data.IMAGE_VERSION, pipeline_data.IMAGE_NAME]
+
+    def run_step(self, data):
+        try:
+            # Read evolene-local-packages.json
+            evolene_local_packages_json_path = file_util.get_absolue_path('/evolene-local-packages.json')
+            has_evolene_local_packages_json = os.path.isfile(evolene_local_packages_json_path)
+
+            if not has_evolene_local_packages_json:
+                # This app doesn't have local packages to inject
+                return data
+
+            self.log.info(f'Found evolene-local-packages.json, injecting local workspace packages.')
+            with open(evolene_local_packages_json_path) as f:
+                local_packages = json.load(f)
+
+            # Check if subdir evolene_local_packages/ exists
+            evolene_local_packages_path = file_util.get_absolue_path('/evolene_local_packages')
+            has_evolene_local_packages = os.path.isdir(evolene_local_packages_path)
+            if not has_evolene_local_packages:
+                os.mkdir(evolene_local_packages_path)
+
+            # Copy local packages
+            for package_name, pkg in local_packages.items():
+                # Need to add leading slash to source path
+                src = file_util.get_absolue_path(f"/{pkg.path}", from_repos_root=True)
+                dest = file_util.get_absolue_path(f'/evolene_local_packages/{package_name}')
+                shutil.copytree(src, dest, dirs_exist_ok=True)
+
+        except:
+            ci_status.post_local_build(data, ci_status.STATUS_ERROR, 10, text_cleaner.clean(sys.exc_info()[0]))
+            self.handle_step_error("Error when injecting local NPM Workspace packages. Remove evolene-local-packages.json from your project to skip this step on next run.", sys.exc_info()[0])
+
+        self.step_ok()
+        return data

--- a/modules/pipeline_steps/inject_npm_workspace_packages.py
+++ b/modules/pipeline_steps/inject_npm_workspace_packages.py
@@ -20,7 +20,7 @@ class InjectNpmWorkspacePackages(AbstractPipelineStep):
         return [environment.PROJECT_ROOT]
 
     def get_required_data_keys(self):
-        return [pipeline_data.IMAGE_VERSION, pipeline_data.IMAGE_NAME]
+        return []
 
     def run_step(self, data):
         try:

--- a/modules/pipeline_steps/inject_npm_workspace_packages.py
+++ b/modules/pipeline_steps/inject_npm_workspace_packages.py
@@ -15,7 +15,7 @@ from modules.util import ci_status
 
 class InjectNpmWorkspacePackages(AbstractPipelineStep):
 
-    name = "Build Docker image"
+    name = "Injecting Local Workspace Packages"
     def get_required_env_variables(self):
         return [environment.PROJECT_ROOT]
 

--- a/modules/pipelines/docker_deploy_pipeline.py
+++ b/modules/pipelines/docker_deploy_pipeline.py
@@ -10,6 +10,7 @@ from modules.pipeline_steps.setup_step import SetupStep
 from modules.pipeline_steps.read_conf_step import ReadConfFileStep
 from modules.pipeline_steps.image_version_step import ImageVersionStep
 from modules.pipeline_steps.docker_file_step import DockerFileStep
+from modules.pipeline_steps.inject_npm_workspace_packages import InjectNpmWorkspacePackages
 from modules.pipeline_steps.build_local_step import BuildLocalStep
 from modules.pipeline_steps.build_environment_to_file_step import BuildEnvironmentToFileStep
 from modules.pipeline_steps.test_image_step import TestImageStep
@@ -60,6 +61,8 @@ class DockerDeployPipeline(object):
             RepoSupervisorStep(),
             # Create docker --build-arg
             DockerCreateBuildArgStep(),
+            # Inject local packages from NPM Workspace monorepos
+            InjectNpmWorkspacePackages(),
             # Build the image to local registry
             BuildLocalStep(),
             # It never to late to party

--- a/modules/util/environment.py
+++ b/modules/util/environment.py
@@ -128,6 +128,8 @@ def get_project_root():
         return os.path.join(os.environ.get(PROJECT_ROOT), os.environ.get(MONOREPO_SUBPATH))
     return os.environ.get(PROJECT_ROOT)
 
+def get_repos_root():
+    return os.environ.get(PROJECT_ROOT)
 
 def get_clone_path():
     return os.environ.get(PROJECT_ROOT)

--- a/modules/util/file_util.py
+++ b/modules/util/file_util.py
@@ -27,7 +27,9 @@ def read_as_string_absolute(file_path):
             return afile.read()
     return None
 
-def get_absolue_path(relative_file_path):
+def get_absolue_path(relative_file_path, from_repos_root=False):
+    if from_repos_root:
+        return '{}{}'.format(get_repos_root(), relative_file_path)
     return '{}{}'.format(get_project_root(), relative_file_path)
 
 def get_docker_mounted_path(relative_file_path):
@@ -35,6 +37,9 @@ def get_docker_mounted_path(relative_file_path):
 
 def get_project_root():
     return environment.get_project_root().rstrip('/')
+
+def get_repos_root():
+    return environment.get_repos_root().rstrip('/')
 
 def is_file(relative_file_path):
     return os.path.isfile(get_absolue_path(relative_file_path))


### PR DESCRIPTION
If a "project" has a file called `evolene-local-packages.json` that looks like this:
`
{
    "kpm-api-common": {
        "path": "packages/kpm-api-common"
    }
}
`
The subfolders of each entry will be copied to the project subfolder `evolene_local_packages/`.

These can then be sent to Docker when creating the image so the image builder can use them inside the image.