### PR TITLE
Allow working on sub projects when injecting local packages

### DIFF
--- a/modules/pipeline_steps/inject_npm_workspace_packages.py
+++ b/modules/pipeline_steps/inject_npm_workspace_packages.py
@@ -28,8 +28,8 @@ class InjectNpmWorkspacePackages(AbstractPipelineStep):
             '''
             evolene-sub-projects.json:
             {
-                "[sub-project-name": {
-                    "path": "path/from/project/root"
+                "[sub-project-name]": {
+                    "path": "[path/from/project/root]"
                 }
             }
             NOTE: Project root is the folder containing the Dockerfile
@@ -62,7 +62,7 @@ class InjectNpmWorkspacePackages(AbstractPipelineStep):
             evolene-local-packages.json:
             {
                 "[package-name]": {
-                    "path": "path/from/repos/root"
+                    "path": "[path/from/repos/root]"
                 }
             }
         '''

--- a/modules/pipeline_steps/inject_npm_workspace_packages.py
+++ b/modules/pipeline_steps/inject_npm_workspace_packages.py
@@ -47,6 +47,7 @@ class InjectNpmWorkspacePackages(AbstractPipelineStep):
                     tmpSubPath = sub_prj["path"].strip('/')
                     self.inject_local_packages(f'/{tmpSubPath}')
             else:
+                self.log.info(f'Checking root of project.')
                 self.inject_local_packages()
 
         except:


### PR DESCRIPTION
It is not uncommon that the backend app serves the frontend app as a set of bundled javascript/css/etc. In order to prepare this we need to build the frontend and copy a build/dist folder to the backend. In these cases `evolene-local-packages.json` will reside in subfolders of the evolene project.

By adding `evolene-sub-projects.json` the project root (the folder containing the Dockerfile) you can tell inject_npm_workspace_packages to act on a given set of sub folders:

```JSON
{
    "[sub-project-name]": {
        "path": "[path/from/project/root]"
    }
}
```